### PR TITLE
Python/access switching owt

### DIFF
--- a/cuckoo_time_translator_python/CMakeLists.txt
+++ b/cuckoo_time_translator_python/CMakeLists.txt
@@ -24,7 +24,7 @@ endif ()
 
 
 find_package(PythonLibs REQUIRED)
-find_package(Boost REQUIRED COMPONENTS python) 
+find_package(Boost REQUIRED COMPONENTS python)
 
 include_directories(${PYTHON_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
@@ -33,14 +33,14 @@ cs_add_library(${PROJECT_NAME}
   src/module.cpp
 )
 string(REGEX REPLACE "_python$" "" LIB_OUTPUT_DIR ${CATKIN_PACKAGE_PYTHON_DESTINATION})
-set_target_properties(${PROJECT_NAME} 
-    PROPERTIES 
+set_target_properties(${PROJECT_NAME}
+    PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${LIB_OUTPUT_DIR}
 )
 
 if (APPLE)
-    set_target_properties(${PROJECT_NAME} 
-        PROPERTIES 
+    set_target_properties(${PROJECT_NAME}
+        PROPERTIES
             SUFFIX ".so" # This is apparently needed for Darvin. But why?
     )
 endif ()
@@ -51,7 +51,7 @@ cs_install()
 cs_export()
 
 if(CATKIN_ENABLE_TESTING)
-catkin_add_nosetests( 
+catkin_add_nosetests(
   test/Test.py
   DEPENDENCIES ${PROJECT_NAME}
 )

--- a/cuckoo_time_translator_python/src/module.cpp
+++ b/cuckoo_time_translator_python/src/module.cpp
@@ -60,6 +60,7 @@ void exportTimestampOwts()
 
   class_<SwitchingOwt, bases<OneWayTranslator>, boost::noncopyable>("SwitchingOwt", init<double, const OneWayTranslator &>())
     .def("getSwitchingTimeSeconds", &SwitchingOwt::getSwitchingTimeSeconds, "double getSwitchingTimeSeconds() const")
+    .def("getCurrentOwt", static_cast<OneWayTranslator& (SwitchingOwt::*)()>(&SwitchingOwt::getCurrentOwt), return_internal_reference<>(), "OneWayTranslator& getCurrentOwt()")
     ;
 
 }


### PR DESCRIPTION
- Fixes https://github.com/ethz-asl/cuckoo_time_translator/issues/40 with the solution of @HannesSommer 
- Remove some whitespace
- Tested in https://github.com/ethz-asl/leica_totalstation_interface/pull/18

```
from cuckoo_time_translator import SwitchingOwt, ConvexHullOwt, RemoteTime, LocalTime
time_translator = SwitchingOwt(3600, ConvexHullOwt())
# update and translate...
if time_translator.isReady():
    print("Offset: %s"%float(time_translator.getCurrentOwt().getOffset()))
    print("Skew: %s"%time_translator.getCurrentOwt().getSkew())
```
