### PR TITLE
Remove outdated driver_base package.

### DIFF
--- a/cuckoo_time_translator/package.xml
+++ b/cuckoo_time_translator/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>catkin_simple</buildtool_depend>
 
   <depend>roscpp</depend>
-  <depend>driver_base</depend>
   <depend>dynamic_reconfigure</depend>
 
   <build_depend>message_generation</build_depend>


### PR DESCRIPTION
I think this is not used anywhere, or am I wrong?

According to [this](https://github.com/ros-drivers/driver_common/blob/indigo-devel/driver_base/package.xml#L6) comment, `driver_base` is outdated.