### PR TITLE
Prevent catkin_simple from exporting the library (.so).

### DIFF
--- a/cuckoo_time_translator_python/CMakeLists.txt
+++ b/cuckoo_time_translator_python/CMakeLists.txt
@@ -32,6 +32,7 @@ catkin_python_setup()
 
 cs_add_library(${PROJECT_NAME}
   src/module.cpp
+  NO_AUTO_EXPORT
 )
 
 string(REGEX REPLACE "_python$" "" LIB_OUTPUT_DIR ${CATKIN_PACKAGE_PYTHON_DESTINATION})


### PR DESCRIPTION
@rikba , this little change should solve the catkin part of issue, #49.
