### PR TITLE
WIP: Allow plotting wall clock time on x-axis.

### DIFF
--- a/cuckoo_time_translator_python/python/cuckoo_time_translator_python/plotting.py
+++ b/cuckoo_time_translator_python/python/cuckoo_time_translator_python/plotting.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 import matplotlib
+import datetime
 
 import matplotlib.pyplot as plt
 
@@ -25,7 +26,7 @@ def save(fig, legend, fileName, fileFormat='pdf', overwrite=False):
     fig.savefig(fullFileName, bbox_inches='tight', format=fileFormat)
 
 
-def plotMultiDelays(x, delays, xLabel, labels=None, title=None, markersize=1.5, fileName=None, overwrite=None, colors=None, block=False, show=False):
+def plotMultiDelays(x, delays, xLabel, labels=None, title=None, markersize=1.5, fileName=None, overwrite=None, colors=None, block=False, show=False, wallclock=False):
     if not colors:
         defaultColors = ['r', 'g', 'b']
         colors = list(reversed(defaultColors[:len(delays)]))
@@ -39,8 +40,11 @@ def plotMultiDelays(x, delays, xLabel, labels=None, title=None, markersize=1.5, 
     breakX = False
 
     def plotMyDelays(ax):
-        xA = np.array(x, dtype=float)
-        xA = xA - min(xA[~np.isnan(xA)])
+        if wallclock:
+            xA = np.array([datetime.datetime.fromtimestamp(b) for b in x], dtype='datetime64')
+        else:
+            xA = np.array(x, dtype=float)
+            xA = xA - xA[~np.isnan(xA)].min()
         if labels:
             for i, (d, l) in enumerate(zip(delays, labels)):
                 assert(len(xA) == len(d))

--- a/cuckoo_time_translator_python/scripts/ctt_introspect.py
+++ b/cuckoo_time_translator_python/scripts/ctt_introspect.py
@@ -27,6 +27,7 @@ if __name__ == '__main__':
   parser.add_argument('--invalidate', action='store_true', help='invalidate any possibly existing cache')
   parser.add_argument('--showDefaults', action='store_true', help='Show all parameters in the legend even if they are at their default value')
   parser.add_argument('--force', action='store_true', help='Force overwriting')
+  parser.add_argument('--wallclock', action='store_true', help='Show wall clock time on x-axis')
 
   args = parser.parse_args()
   verbosity = args.verbose
@@ -97,7 +98,7 @@ if __name__ == '__main__':
       printDelayStat(d, lab)
 
     from cuckoo_time_translator_python.plotting import plotMultiDelays, show
-    plotMultiDelays(base_times, delaysToPlot, "time [sec]", labels, markersize=4, colors=colors, fileName=args.output, overwrite=args.force, show=False)
+    plotMultiDelays(base_times, delaysToPlot, "time [sec]", labels, markersize=4, colors=colors, fileName=args.output, overwrite=args.force, show=False, wallclock=args.wallclock)
 
   if not args.output:
     from cuckoo_time_translator_python.plotting import show


### PR DESCRIPTION
To correlate what we see in the ctt_introspect plot with other sources (journald, logs) I figured it might be nice to have absolute timestamps shown rather than offsets wrt start of the file.